### PR TITLE
Added ShB_EW and BMRAI distance antistuck dist

### DIFF
--- a/Fate Farming.lua
+++ b/Fate Farming.lua
@@ -275,6 +275,265 @@ FatesData = {
         }
     },
     {
+        zoneName = "Lakeland",
+        zoneId = 813,
+        aetheryteList = {
+            { aetheryteName="The Ostall Imperative", x=-735, y=53, z=-230 },
+            { aetheryteName="Fort Jobb", x=753, y=24, z=-28 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Pick-up Sticks",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Calm a Chameleon",
+                "A Beast among Men",
+                "Draconian Measures",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Kholusia",
+        zoneId = 814,
+        aetheryteList = {
+            { aetheryteName="Stilltide", x=668, y=29, z=289 },
+            { aetheryteName="Wright", x=-244, y=20, z=385 },
+            { aetheryteName="Tomra", x=-426, y=419, z=-623 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Ironbeard Builders - Rebuilt",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Not Today (FATE)",
+                "A Finale Most Formidable",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Amh Araeng",
+        zoneId = 815,
+        aetheryteList = {
+            { aetheryteName="Mord Souq", x=246, y=12, z=-220 },
+            { aetheryteName="Twine", x=-511, y=47, z=-212 },
+            { aetheryteName="The Inn at Journey's Head", x=399, y=-24, z=307 },
+        },
+        fatesList= {
+            collectionsFates= {},
+            otherNpcFates= {},
+            bossFates= {
+                "Bayawak Attack",
+                "The Elderblade",
+                "The Odd Couple",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Il Mheg",
+        zoneId = 816,
+        aetheryteList = {
+            { aetheryteName="Lydha Lran", x=-344, y=48, z=512 },
+            { aetheryteName="Wolekdorf", x=380, y=87, z=-687 },
+            { aetheryteName="Pla Enni", x=-72, y=103, z=-857 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Twice Upon a Time",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Thrice Upon a Time",
+                "Locus Terribilis",
+                "Mad Magic",
+                "Brute Fuath",
+                "Breaking the Fuath Wall",
+                "Go Fuath a Conqueror",
+                "Fuath to Be Reckoned With",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "The Rak'tika Greatwood",
+        zoneId = 817,
+        aetheryteList = {
+            { aetheryteName="Slitherbough", x=-103, y=-19, z=297 },
+            { aetheryteName="Fanow", x=382, y=21, z=-194 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Picking up the Pieces",
+                "Pluck of the Draw",
+                "Monkeying Around",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Attack of the Killer Tomatl",
+                "I'll Be Bark",
+                "Tojil War",
+                "Tojil Annihilation",
+                "Tojil Carnage",
+                "Tojil Eclipse",
+                "Attack the Block",
+                "Queen of the Harpies",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "The Tempest",
+        zoneId = 818,
+        aetheryteList = {
+            { aetheryteName="The Ondo Cups", x=561, y=352, z=-199 },
+            { aetheryteName="The Macarenses Angle", x=-141, y=-280, z=218 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Low Coral Fiber",
+                "Pearls Apart",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Ondo of Blood",
+                "The Devil in the Deep Blue Sea",
+                "The Head, the Tail, the Whole Damned Thing",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Labyrinthos",
+        zoneId = 956,
+        aetheryteList = {
+            { aetheryteName="The Archeion", x=443, y=170, z=-476 },
+            { aetheryteName="Sharlayan Hamlet", x=8, y=-27, z=-46 },
+            { aetheryteName="Aporia", x=-729, y=-27, z=302 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Sheaves on the Wind",
+                "Moisture Farming",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Let It Grow",
+                "Incident Files: Steamed Vegetable",
+                "The Frailty of Life",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Thavnair",
+        zoneId = 957,
+        aetheryteList = {
+            { aetheryteName="Yedlihmad", x=193, y=6, z=629 },
+            { aetheryteName="The Great Work", x=-527, y=4, z=36 },
+            { aetheryteName="Palaka's Stand", x=405, y=5, z=-244 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Full Petal ALchemist: Perilous Pickings",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "The Accursed Kanabhuti",
+                "Return of the Tyrant",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Garlemald",
+        zoneId = 958,
+        aetheryteList = {
+            { aetheryteName="Camp Broken Glass", x=-408, y=24, z=479 },
+            { aetheryteName="Tertium", x=518, y=-35, z=-178 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Parts Unknown",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Artificial Malevolence: 15 Minutes to Comply",
+                "Roses Are Red, Violence is Due",
+                "Artificial Malevolence: Mighty Metatron",
+                "The Man with the Golden Son",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Mare Lamentorum",
+        zoneId = 959,
+        aetheryteList = {
+            { aetheryteName="Sinus Lacrimarum", x=-566, y=134, z=650 },
+            { aetheryteName="Bestways Burrow", x=-0, y=-128, z=-512 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "What a Thrill",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "The Stones of Silence",
+                "Lepus Lamentorum: Crazy Contraption",
+                "Head Empty, Only Thoughts"
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Ultima Thule",
+        zoneId = 960,
+        aetheryteList = {
+            { aetheryteName="Reah Tahra", x=-544, y=74, z=269 },
+            { aetheryteName="Abode of the Ea", x=64, y=272, z=-657 },
+            { aetheryteName="Base omicron", x=-489, y=437, z=333 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "Omicron Recall: Comms Expansion"
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Far from the Madding Horde",
+                "Nevermore",
+                "Wings of Glory",
+                "Omicron Recall: Killing Order",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
+        zoneName = "Elpis",
+        zoneId = 961,
+        aetheryteList = {
+            { aetheryteName="Anagnorisis", x=159, y=11, z=126 },
+            { aetheryteName="The Twelve Wonders", x=-633, y=-19, z=542 },
+            { aetheryteName="Poieten Oikos", x=-529, y=161, z=-222 },
+        },
+        fatesList= {
+            collectionsFates= {
+                "So Sorry, Sokles",
+            },
+            otherNpcFates= {},
+            bossFates= {
+                "Grand Designs: lo",
+                "The Rustling of Murderous Leaves",
+                "Grand Designs: The Newest of New",
+                "Eurydike: All Bark, No Bite",
+            },
+            blacklistedFates= {}
+        }
+    },
+    {
         zoneName = "Urqopacha",
         zoneId = 1187,
         aetheryteList = {
@@ -460,7 +719,16 @@ end
 
 --Optional Plugin Warning
 if EnableChangeInstance == true  then
-    if HasPlugin("Lifestream") == false then
+    -- Only DT zones with instances currently
+    -- Urqopacha, Kozama'uka, Yak T'el, Shaaloani, Heritage Found, Living Memory
+    if not IsInZone(1187) and --Urqopacha
+       not IsInZone(1188) and --Kozama'uka
+       not IsInZone(1189) and --Yak T'el
+       not IsInZone(1190) and --Shaaloani
+       not IsInZone(1191) and --Heritage Found
+       not IsInZone(1192) then --Living Memory
+        EnableChangeInstance = false
+    elseif HasPlugin("Lifestream") == false then
         yield("/echo [FATE] Please Install Lifestream or Disable ChangeInstance in the settings")
     end
 end
@@ -799,10 +1067,10 @@ function InteractWithFateNpc(fate)
             ClearTarget()
             yield("/wait 1")
         end
-    end
+        end
     yield("/echo [FATE] Fate begun")
-    LogInfo("[FATE] Exiting InteractWithFateNpc")
-end
+        LogInfo("[FATE] Exiting InteractWithFateNpc")
+    end
 
 --Paths to the enemy (for Meele)
 function EnemyPathing()
@@ -917,9 +1185,59 @@ function antistuck()
     PXX = GetPlayerRawXPos()
     PYY = GetPlayerRawYPos()
     PZZ = GetPlayerRawZPos()
+    --[[
+        Gladiator => 1
+        Pugilist => 2
+        Marauder => 3
+        Lancer => 4
+        Archer => 5
+        Conjurer => 6
+        Thaumaturge => 7
+        Paladin => 19
+        Monk => 20
+        Warrior => 21
+        Dragoon => 22
+        Bard => 23
+        WhiteMage => 24
+        BlackMage => 25
+        Arcanist => 26
+        Summoner => 27
+        Scholar => 28
+        Rogue => 29
+        Ninja => 30
+        Machinist => 31
+        DarkKnight => 32
+        Astrologian => 33
+        Samurai => 34
+        RedMage => 35
+        BlueMage => 36
+        Gunbreaker => 37
+        Dancer => 38
+        Reaper => 39
+        Sage => 40
+        Viper => 41
+        Pictomancer => 42
+    --]]
+    --Ranged attacks and spells max distance to be usable is 25.49y, 25.5 is "target out of range"
+    --Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
+    --ranged and casters have a further max distance so not always running all way up to target
+    local ClassJob = GetClassJobId()
+    local AntiStuckDist = 3.5 -- default to melee distance
+    if ClassJob == 5 or ClassJob == 23 or -- Archer/Bard
+       ClassJob == 6 or ClassJob == 24 or -- Conjurer/White Mage
+       ClassJob == 7 or ClassJob == 25 or -- Thaumaturge/Black Mage
+       ClassJob == 26 or ClassJob == 27 or ClassJob == 28 or -- Arcanist/Summoner/Scholar
+       ClassJob == 31 or -- Machinist
+       ClassJob == 33 or -- Astrologian
+       ClassJob == 35 or -- Red Mage
+       ClassJob == 38 or -- Dancer
+       ClassJob == 40 or -- Sage
+       ClassJob == 42 then -- Pictomancer
+        AntiStuckDist = 20 -- max distance for ranged to attack is 25.5
+    end
 
     if PX == PXX and PY == PYY and PZ == PZZ then
-        while GetDistanceToTarget() > 3.5 and stuck < 20 do
+        while GetDistanceToTarget() > AntiStuckDist and stuck < 20 do
             LogInfo("[FATE] Looping antistuck")
             local enemy_x = GetTargetRawXPos()
             local enemy_y = GetTargetRawYPos()
@@ -1162,10 +1480,61 @@ while true do
         --Activates Bossmod upon landing in a fate
         if not GetCharacterCondition(CharacterCondition.mounted) and not bossModAIActive then 
             if useBMR then
+                --[[
+                    Ranged attacks and spells max distance to be usable is 25.49y, 25.5 is "target out of range"
+                    Melee attacks (auto attacks) max distance is 2.59y, 2.60 is "target out of range"
+                    Gladiator => 1
+                    Pugilist => 2
+                    Marauder => 3
+                    Lancer => 4
+                    Archer => 5
+                    Conjurer => 6
+                    Thaumaturge => 7
+                    Paladin => 19
+                    Monk => 20
+                    Warrior => 21
+                    Dragoon => 22
+                    Bard => 23
+                    WhiteMage => 24
+                    BlackMage => 25
+                    Arcanist => 26
+                    Summoner => 27
+                    Scholar => 28
+                    Rogue => 29
+                    Ninja => 30
+                    Machinist => 31
+                    DarkKnight => 32
+                    Astrologian => 33
+                    Samurai => 34
+                    RedMage => 35
+                    BlueMage => 36
+                    Gunbreaker => 37
+                    Dancer => 38
+                    Reaper => 39
+                    Sage => 40
+                    Viper => 41
+                    Pictomancer => 42
+                --]]
                 yield("/bmrai on")
                 yield("/bmrai followtarget on")
                 yield("/bmrai followcombat on")
                 yield("/bmrai followoutofcombat on")
+                local ClassJob = GetClassJobId()
+                local MaxDistance = 2.5 --default to melee distance
+                --ranged and casters have a further max distance so not always running all way up to target
+                if ClassJob == 5 or ClassJob == 23 or -- Archer/Bard
+                   ClassJob == 6 or ClassJob == 24 or -- Conjurer/White Mage
+                   ClassJob == 7 or ClassJob == 25 or -- Thaumaturge/Black Mage
+                   ClassJob == 26 or ClassJob == 27 or ClassJob == 28 or -- Arcanist/Summoner/Scholar
+                   ClassJob == 31 or -- Machinist
+                   ClassJob == 33 or -- Astrologian
+                   ClassJob == 35 or -- Red Mage
+                   ClassJob == 38 or -- Dancer
+                   ClassJob == 40 or -- Sage
+                   ClassJob == 42 then -- Pictomancer
+                   MaxDistance = 15
+                end
+                yield("/bmrai maxdistancetarget " .. MaxDistance)
                 bossModAIActive = true
                 yield("/wait 3")
             end
@@ -1284,7 +1653,7 @@ while true do
     end
 
     --Retainer Process
-    if Retainers and not GetCharacterCondition(CharacterCondition.inCombat) then 
+    if Retainers and not GetCharacterCondition(CharacterCondition.inCombat) then
         LogInfo("[FATE] Handling retainers...")
         if ARRetainersWaitingToBeProcessed() == true then
             while not IsInZone(129) do
@@ -1360,8 +1729,8 @@ while true do
     end
 
 
-    ------------------------------Vouchers-----------------------------------------------
-    --old Vouchers!
+------------------------------Vouchers-----------------------------------------------
+--old Vouchers!
     if gems > 1400 and Exchange == true and OldV == true then
         LogInfo("[FATE] Exchanging for old vouchers.")
         TeleportTo("Old Sharlayan")


### PR DESCRIPTION
Added ShB and EW zones along with collections and boss fates from wiki. Also added some additional logic for setting BMR max distance for casters/ranged jobs so that player isn't always running right up next to enemies. As a result the antistuck function needed some similar changes to allow for further distances on the ranged jobs as well. 